### PR TITLE
Add auto_apply setting into workspace

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -74,7 +74,3 @@ jobs:
     - name: Terraform Plan Status
       if: steps.plan.outcome == 'failure'
       run: exit 1
-
-    - name: Terraform Apply
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: terraform apply -auto-approve

--- a/tfe.tf
+++ b/tfe.tf
@@ -10,6 +10,7 @@ resource "tfe_organization" "sean-ahn" {
 #   organization        = tfe_organization.sean-ahn.name
 #   speculative_enabled = true
 #   queue_all_runs      = false
+#   auto_apply          = true
 #   vcs_repo {
 #     identifier     = "sean-ahn/iac"
 #     oauth_token_id = ""


### PR DESCRIPTION
```
╷
│ Error: Apply not allowed for workspaces with a VCS connection
│ 
│ A workspace that is connected to a VCS requires the VCS-driven workflow to
│ ensure that the VCS remains the single source of truth.
╵
```